### PR TITLE
Bugfix/address struct size issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,141 @@
+# Python-Comtrade Temp Test Files
+tests/temp_*
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/comtrade.py
+++ b/comtrade.py
@@ -55,7 +55,7 @@ SEPARATOR = ","
 
 # timestamp regular expression
 re_date = re.compile("([0-9]{1,2})/([0-9]{1,2})/([0-9]{2,4})")
-re_time = re.compile("([0-9]{2}):([0-9]{2}):([0-9]{2})(\\.([0-9]{1,12}))?")
+re_time = re.compile("([0-9]{1,2}):([0-9]{2}):([0-9]{2})(\\.([0-9]{1,12}))?")
 
 
 # Non-standard revision warning
@@ -1022,9 +1022,12 @@ class DatReader:
 
 class AsciiDatReader(DatReader):
     """ASCII format DatReader subclass."""
-    ASCII_SEPARATOR = SEPARATOR
+    def __init__(self):
+        # Call the initialization for the inherited class
+        super().__init__()
+        ASCII_SEPARATOR = SEPARATOR
 
-    DATA_MISSING = ""
+        DATA_MISSING = ""
 
     def parse(self, contents):
         """Parse a ASCII file contents."""
@@ -1067,24 +1070,27 @@ class AsciiDatReader(DatReader):
 
 class BinaryDatReader(DatReader):
     """16-bit binary format DatReader subclass."""
-    ANALOG_BYTES = 2
-    STATUS_BYTES = 2
-    TIME_BYTES = 4
-    SAMPLE_NUMBER_BYTES = 4
+    def __init__(self):
+        # Call the initialization for the inherited class
+        super().__init__()
+        self.ANALOG_BYTES = 2
+        self.STATUS_BYTES = 2
+        self.TIME_BYTES = 4
+        self.SAMPLE_NUMBER_BYTES = 4
 
-    # maximum negative value
-    DATA_MISSING = 0xFFFF
+        # maximum negative value
+        self.DATA_MISSING = 0xFFFF
 
-    read_mode = "rb"
+        self.read_mode = "rb"
 
-    if struct.calcsize("L") == 4:
-        STRUCT_FORMAT = "LL {acount:d}h {dcount:d}H"
-        STRUCT_FORMAT_ANALOG_ONLY = "LL {acount:d}h"
-        STRUCT_FORMAT_STATUS_ONLY = "LL {dcount:d}H"
-    else:
-        STRUCT_FORMAT = "II {acount:d}h {dcount:d}H"
-        STRUCT_FORMAT_ANALOG_ONLY = "II {acount:d}h"
-        STRUCT_FORMAT_STATUS_ONLY = "II {dcount:d}H"
+        if struct.calcsize("L") == 4:
+            self.STRUCT_FORMAT = "LL {acount:d}h {dcount:d}H"
+            self.STRUCT_FORMAT_ANALOG_ONLY = "LL {acount:d}h"
+            self.STRUCT_FORMAT_STATUS_ONLY = "LL {dcount:d}H"
+        else:
+            self.STRUCT_FORMAT = "II {acount:d}h {dcount:d}H"
+            self.STRUCT_FORMAT_ANALOG_ONLY = "II {acount:d}h"
+            self.STRUCT_FORMAT_STATUS_ONLY = "II {dcount:d}H"
 
     def get_reader_format(self, analog_channels, status_bytes):
         # Number of status fields of 2 bytes based on the total number of 

--- a/comtrade.py
+++ b/comtrade.py
@@ -1184,21 +1184,35 @@ class BinaryDatReader(DatReader):
 
 class Binary32DatReader(BinaryDatReader):
     """32-bit binary format DatReader subclass."""
-    ANALOG_BYTES = 4
+    def __init__(self):
+        # Call the initialization for the inherited class
+        super().__init__()
+        self.ANALOG_BYTES = 4
 
-    STRUCT_FORMAT = "LL {acount:d}l {dcount:d}H"
-    STRUCT_FORMAT_ANALOG_ONLY = "LL {acount:d}l"
+        if struct.calcsize("L") == 4:
+            self.STRUCT_FORMAT = "LL {acount:d}l {dcount:d}H"
+            self.STRUCT_FORMAT_ANALOG_ONLY = "LL {acount:d}l"
+        else:
+            self.STRUCT_FORMAT = "II {acount:d}i {dcount:d}H"
+            self.STRUCT_FORMAT_ANALOG_ONLY = "II {acount:d}i"
 
-    # maximum negative value
-    DATA_MISSING = 0xFFFFFFFF
+        # maximum negative value
+        self.DATA_MISSING = 0xFFFFFFFF
 
 
 class Float32DatReader(BinaryDatReader):
     """Single precision (float) binary format DatReader subclass."""
-    ANALOG_BYTES = 4
+    def __init__(self):
+        # Call the initialization for the inherited class
+        super().__init__()
+        self.ANALOG_BYTES = 4
 
-    STRUCT_FORMAT = "LL {acount:d}f {dcount:d}H"
-    STRUCT_FORMAT_ANALOG_ONLY = "LL {acount:d}f"
+        if struct.calcsize("L") == 4:
+            self.STRUCT_FORMAT = "LL {acount:d}f {dcount:d}H"
+            self.STRUCT_FORMAT_ANALOG_ONLY = "LL {acount:d}f"
+        else:
+            self.STRUCT_FORMAT = "II {acount:d}f {dcount:d}H"
+            self.STRUCT_FORMAT_ANALOG_ONLY = "II {acount:d}f"
 
-    # Maximum negative value
-    DATA_MISSING = sys.float_info.min
+        # Maximum negative value
+        self.DATA_MISSING = sys.float_info.min

--- a/comtrade.py
+++ b/comtrade.py
@@ -1025,9 +1025,9 @@ class AsciiDatReader(DatReader):
     def __init__(self):
         # Call the initialization for the inherited class
         super().__init__()
-        ASCII_SEPARATOR = SEPARATOR
+        self.ASCII_SEPARATOR = SEPARATOR
 
-        DATA_MISSING = ""
+        self.DATA_MISSING = ""
 
     def parse(self, contents):
         """Parse a ASCII file contents."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -273,7 +273,10 @@ class TestBinaryReading(unittest.TestCase):
         return int(analog_value)
 
     def getFormat(self):
-        return 'Lf h H'
+        if struct.calcsize("L") == 4:
+            return 'Lf h H'
+        else:
+            return 'If h H'
 
     def setUp(self):
         # Sample auto-generated Comtrade file.
@@ -365,7 +368,10 @@ class TestBinary32Reading(TestBinaryReading):
         return int(analog_value)
 
     def getFormat(self):
-        return 'Lf l H'
+        if struct.calcsize("L") == 4:
+            return 'Lf l H'
+        else:
+            return 'If i H'
 
 
 class TestFloat32Reading(TestBinaryReading):
@@ -376,7 +382,10 @@ class TestFloat32Reading(TestBinaryReading):
         return int(analog_value)
 
     def getFormat(self):
-        return 'Lf f H'
+        if struct.calcsize("L") == 4:
+            return 'Lf f H'
+        else:
+            return 'If f H'
 
 
 class TestRealBinaryReading(unittest.TestCase):


### PR DESCRIPTION
# Addresses Issues:
* #16 
* #15 

# Changelog:
* Adjusted RegEx to allow timestamp to utilize single character hour (note deviation from COMTRADE standard to be more flexible)
* Adjusted various DAT readers to utilize `__init__` methods and `super().__init__()` calls to address variable overriding issue.
* Added `.gitignore` file to ignore test/temp files which are automatically generated.

# Affected Users:
* @nolanbell