### PR TITLE
allowing spaces between time and date

### DIFF
--- a/comtrade.py
+++ b/comtrade.py
@@ -55,7 +55,7 @@ SEPARATOR = ","
 
 # timestamp regular expression
 re_date = re.compile("([0-9]{1,2})/([0-9]{1,2})/([0-9]{2,4})")
-re_time = re.compile("([0-9]{1,2}):([0-9]{2}):([0-9]{2})(\\.([0-9]{1,12}))?")
+re_time = re.compile("[\s]*([0-9]{1,2}):([0-9]{2}):([0-9]{2})(\\.([0-9]{1,12}))?")
 
 
 # Non-standard revision warning


### PR DESCRIPTION
There was an issue (more specifically, an exception: **TypeError: cannot unpack non-iterable NoneType object**) when I tried to read some oscillographies created from ATP Draw simulations and it turned out to be because of a space after the comma that separates date and time, changing a little bit the regular expression fixed the issue