### PR TITLE
Resolve rev 1991 date order

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ https://github.com/dparrini/python-comtrade
 
 Feel free to report any bugs you find. You are welcome to fork and submit pull requests.
 
+## Development
+
+To run tests, use Python's `unittest`. From a clone of the GitHub repository, run the command:
+
+#### On Windows
+```
+python -m unittest tests\tests.py
+```
+
+#### On Linux:
+```
+python3 -m unittest ./tests/tests.py
+```
+
 ## License
 
 The module is available at [GitHub](https://github.com/dparrini/python-comtrade) under the MIT license.

--- a/comtrade.py
+++ b/comtrade.py
@@ -127,7 +127,7 @@ def fill_with_zeros_to_the_right(number_str: str, width: int):
     return number_str
 
 
-def _read_timestamp(timestamp_line: str, ignore_warnings=False) -> tuple:
+def _read_timestamp(timestamp_line: str, rev_year: str, ignore_warnings: bool = False) -> tuple:
     """Process comma separated fields and returns a tuple containing the timestamp
     and a boolean value indicating whether nanoseconds are used.
     Can possibly return the timestamp 00/00/0000 00:00:00.000 for empty strings
@@ -139,7 +139,12 @@ def _read_timestamp(timestamp_line: str, ignore_warnings=False) -> tuple:
         if len(values) >= 2:
             date_str, time_str = values[0:2]
             if len(date_str.strip()) > 0:
-                day, month, year = _get_date(date_str)
+                # 1991 Format Uses mm/dd/yyyy format
+                if rev_year == REV_1991:
+                    month, day, year = _get_date(date_str)
+                # Modern Formats Use dd/mm/yyyy format
+                else:
+                    day, month, year = _get_date(date_str)
             if len(time_str.strip()) > 0:
                 hour, minute, second, microsecond, \
                     nanosec = _get_time(time_str, ignore_warnings)
@@ -451,14 +456,22 @@ class Cfg:
         # First data point time and time base
         line = cfg.readline()
         ts_str = line.strip()
-        self._start_timestamp, nanosec = _read_timestamp(ts_str, self.ignore_warnings)
+        self._start_timestamp, nanosec = _read_timestamp(
+            ts_str,
+            self._cfg.rev_year,
+            self.ignore_warnings
+        )
         self._time_base = self._get_time_base(nanosec)
         line_count = line_count + 1
 
         # Event data point and time base
         line = cfg.readline()
         ts_str = line.strip()
-        self._trigger_timestamp, nanosec = _read_timestamp(ts_str, self.ignore_warnings)
+        self._trigger_timestamp, nanosec = _read_timestamp(
+            ts_str,
+            self._cfg.rev_year,
+            self.ignore_warnings
+        )
         self._time_base = min([self.time_base, self._get_time_base(nanosec)])
         line_count = line_count + 1
 

--- a/comtrade.py
+++ b/comtrade.py
@@ -458,7 +458,7 @@ class Cfg:
         ts_str = line.strip()
         self._start_timestamp, nanosec = _read_timestamp(
             ts_str,
-            self._cfg.rev_year,
+            self.rev_year,
             self.ignore_warnings
         )
         self._time_base = self._get_time_base(nanosec)
@@ -469,7 +469,7 @@ class Cfg:
         ts_str = line.strip()
         self._trigger_timestamp, nanosec = _read_timestamp(
             ts_str,
-            self._cfg.rev_year,
+            self.rev_year,
             self.ignore_warnings
         )
         self._time_base = min([self.time_base, self._get_time_base(nanosec)])


### PR DESCRIPTION
### Linked Issue:
#22 

### Affected Users:
* @lkxajd

### Changelog:
* Altered `_read_timestamp` to accept additional input to qualify COMTRADE year format.
* Adjusted order of month/year/day extraction to meet specifications placed by 1991 format:
![image](https://user-images.githubusercontent.com/33275230/131778878-7242d10a-82b7-4bcf-951e-178748b7e658.png)