### PR TITLE
Add auto-detection for decoding bytes to string when parsing an ASCII Data file.

### DIFF
--- a/comtrade.py
+++ b/comtrade.py
@@ -1120,6 +1120,9 @@ class AsciiDatReader(DatReader):
 
     def parse(self, contents):
         """Parse a ASCII file contents."""
+        # Check if contents has been read as a io.BytesIO object, if so, decode into a string.
+        contents = contents.decode() if (type(contents) == bytes) else contents
+
         analog_count = self._cfg.analog_count
         status_count = self._cfg.status_count
         time_mult = self._cfg.timemult


### PR DESCRIPTION
Hi, I'm working on using Apache Spark to read in massive amounts of COMTRADE files in a distributed computing fashion. The logical flow of this is to read in all `.cfg` files as strings, and all `.dat` files as binary (since we don't know if are ASCII or binary until the `.cfg` file is processed) from a data lake. 

Then the files are joined, based upon their filename, and the `python-comtrade` library is used to process the files on Spark distributed worker nodes.  This line of code checks to see if the `contents` passed into the `parse()` function are of type `bytes` and, if so, decodes them into a string for ASCII processing.